### PR TITLE
献立投稿のタイトルとサムネ画像設定実装

### DIFF
--- a/functions/src/interfaces/post.ts
+++ b/functions/src/interfaces/post.ts
@@ -16,6 +16,8 @@ export interface Post {
   myMenuId: string;
   postId: string;
   createdAt: firestore.Timestamp;
+  title: string;
+  thumbnailURLs: string[];
 }
 
 export interface PostWithFood {
@@ -23,6 +25,8 @@ export interface PostWithFood {
   creatorId: string;
   postId: string;
   createdAt: firestore.Timestamp;
+  title: string;
+  thumbnailURLs: string[];
 }
 
 export interface PostWithFoodWithUser extends PostWithFood {

--- a/src/app/change-my-menu-dialog/change-my-menu-dialog/change-my-menu-dialog.component.ts
+++ b/src/app/change-my-menu-dialog/change-my-menu-dialog/change-my-menu-dialog.component.ts
@@ -8,7 +8,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { FormControl } from '@angular/forms';
 import { SearchIndex } from 'algoliasearch/lite';
 import { SearchService } from 'src/app/services/search.service';
-import { startWith, take } from 'rxjs/operators';
+import { startWith } from 'rxjs/operators';
 import { MyMenu } from '@interfaces/my-menu';
 
 @Component({

--- a/src/app/create-my-menu/create-my-menu.module.ts
+++ b/src/app/create-my-menu/create-my-menu.module.ts
@@ -10,9 +10,10 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { ChangeMyMenuDialogModule } from '../change-my-menu-dialog/change-my-menu-dialog.module';
+import { PostDialogComponent } from './post-dialog/post-dialog.component';
 
 @NgModule({
-  declarations: [CreateMyMenuComponent],
+  declarations: [CreateMyMenuComponent, PostDialogComponent],
   imports: [
     CommonModule,
     CreateMyMenuRoutingModule,

--- a/src/app/create-my-menu/create-my-menu.module.ts
+++ b/src/app/create-my-menu/create-my-menu.module.ts
@@ -8,9 +8,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { ChangeMyMenuDialogModule } from '../change-my-menu-dialog/change-my-menu-dialog.module';
 import { PostDialogComponent } from './post-dialog/post-dialog.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatInputModule } from '@angular/material/input';
 
 @NgModule({
   declarations: [CreateMyMenuComponent, PostDialogComponent],
@@ -23,8 +25,10 @@ import { PostDialogComponent } from './post-dialog/post-dialog.component';
     MatSnackBarModule,
     FormsModule,
     ReactiveFormsModule,
-    MatAutocompleteModule,
     ChangeMyMenuDialogModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatRadioModule,
   ],
 })
 export class CreateMyMenuModule {}

--- a/src/app/create-my-menu/create-my-menu/create-my-menu.component.html
+++ b/src/app/create-my-menu/create-my-menu/create-my-menu.component.html
@@ -4,7 +4,7 @@
     alt="My献立編集画面のタイトル"
     class="content-title"
   />
-  <div class="wood-background" *ngIf="weekMenu$ | async">
+  <div class="wood-background" *ngIf="weekMenu$ | async as weekMenu">
     <img
       src="/assets/images/others/wood-pin.png"
       alt="木のピン"
@@ -12,7 +12,7 @@
       class="wood-pins"
     />
     <div class="week-grid">
-      <div *ngFor="let dayMenu of weekMenu$ | async; let i = index">
+      <div *ngFor="let dayMenu of weekMenu; let i = index">
         <img
           src="/assets/images/titles/day-of-week-title{{ i }}.png"
           alt="{{ dayMenu.dayOfWeek }}曜日のタイトル"
@@ -91,7 +91,11 @@
         </div>
       </div>
     </div>
-    <div class="decoration-btn" (click)="createPost()" *ngIf="!myMenu.isPosted">
+    <div
+      class="decoration-btn"
+      (click)="openPostDialog(weekMenu)"
+      *ngIf="!myMenu.isPosted"
+    >
       <div class="decoration-btn__border">
         <span class="decoration-btn__text">My献立を投稿する</span>
       </div>

--- a/src/app/create-my-menu/create-my-menu/create-my-menu.component.ts
+++ b/src/app/create-my-menu/create-my-menu/create-my-menu.component.ts
@@ -5,11 +5,10 @@ import { DayMenuWithFood, MyMenu } from '@interfaces/my-menu';
 import { Observable, Subscription } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
 import { Food } from '@interfaces/food';
-import { PostService } from 'src/app/services/post.service';
 import { tap } from 'rxjs/operators';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { LoadingService } from 'src/app/services/loading.service';
 import { ChangeMyMenuDialogComponent } from 'src/app/change-my-menu-dialog/change-my-menu-dialog/change-my-menu-dialog.component';
+import { PostDialogComponent } from '../post-dialog/post-dialog.component';
 
 @Component({
   selector: 'app-create-my-menu',
@@ -31,8 +30,6 @@ export class CreateMyMenuComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private myMenuService: MyMenuService,
     private dialog: MatDialog,
-    private postService: PostService,
-    private snackBar: MatSnackBar,
     private loadingService: LoadingService
   ) {
     this.loadingService.toggleLoading(true);
@@ -66,18 +63,15 @@ export class CreateMyMenuComponent implements OnInit, OnDestroy {
     });
   }
 
-  createPost(): void {
-    this.postService
-      .createPost({
-        day: this.myMenu.day,
-        creatorId: this.userId,
-        myMenuId: this.myMenu.myMenuId,
-      })
-      .then(() => {
-        this.snackBar.open('投稿に成功しました！', null);
-        if (!this.myMenu.isPosted) {
-          this.myMenuService.changeMyMenuIsPosted(this.myMenu.myMenuId, true);
-        }
-      });
+  openPostDialog(weekMenu: DayMenuWithFood[]): void {
+    this.dialog.open(PostDialogComponent, {
+      autoFocus: false,
+      restoreFocus: false,
+      data: {
+        weekMenu,
+        myMenu: this.myMenu,
+        userId: this.userId,
+      },
+    });
   }
 }

--- a/src/app/create-my-menu/post-dialog/post-dialog.component.html
+++ b/src/app/create-my-menu/post-dialog/post-dialog.component.html
@@ -1,0 +1,1 @@
+<p>post-dialog works!</p>

--- a/src/app/create-my-menu/post-dialog/post-dialog.component.html
+++ b/src/app/create-my-menu/post-dialog/post-dialog.component.html
@@ -1,1 +1,95 @@
-<p>post-dialog works!</p>
+<div class="wrap">
+  <p class="title">My献立を投稿する</p>
+  <mat-dialog-content>
+    <form [formGroup]="form">
+      <mat-form-field
+        appearance="outline"
+        hintLabel="入力文字数"
+        [hideRequiredMarker]="true"
+        class="form-field"
+      >
+        <mat-label>My献立のタイトル</mat-label>
+        <input
+          matInput
+          formControlName="title"
+          required
+          placeholder="大好物盛り合わせ!!"
+          type="text"
+          autocomplete="off"
+          #input
+        />
+        <mat-hint align="end">{{ input.value?.length || 0 }}/25</mat-hint>
+        <mat-error *ngIf="titleControl.hasError('required')"
+          >必須入力です</mat-error
+        >
+        <mat-error *ngIf="titleControl.hasError('maxlength')"
+          >最大入力文字数を超えています</mat-error
+        >
+      </mat-form-field>
+
+      <div formArrayName="dayOfWeeks" class="formArray">
+        <ng-container
+          *ngFor="let dayOfWeek of dayOfWeeksFormArray.controls; let i = index"
+        >
+          <p class="dayOfWeek-title">{{ data.weekMenu[i].dayOfWeek }}曜日</p>
+          <mat-radio-group
+            [formControl]="dayOfWeek"
+            color="primary"
+            class="radio-group"
+          >
+            <mat-radio-button value="breakfast" class="radio-group__button">{{
+              data.weekMenu[i].breakfast.name
+            }}</mat-radio-button>
+            <mat-radio-button
+              value="lunch"
+              [checked]="true"
+              class="radio-group__button"
+              >{{ data.weekMenu[i].lunch.name }}</mat-radio-button
+            >
+            <mat-radio-button value="dinner" class="radio-group__button">{{
+              data.weekMenu[i].dinner.name
+            }}</mat-radio-button>
+          </mat-radio-group>
+        </ng-container>
+      </div>
+    </form>
+
+    <div class="post" *ngIf="postData$ | async as post">
+      <p class="post__title">{{ post.title }}</p>
+      <div class="post__foods-content">
+        <ng-container *ngFor="let thumbnailURL of post.thumbnailURLs">
+          <div class="post__foods">
+            <div
+              class="post__food-images"
+              [style.background-image]="'url(' + thumbnailURL + ')'"
+            ></div>
+          </div>
+        </ng-container>
+      </div>
+      <div class="post__user-content" *ngIf="user$ | async as user">
+        <img
+          [src]="user.avaterURL"
+          alt="ユーザーのアバター"
+          class="post__user-avater"
+        />
+        <div class="post__user-content-right">
+          <p class="post__user-name">{{ user.name }}</p>
+          <p class="post__date">{{ today | date }}</p>
+        </div>
+      </div>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions align="center">
+    <button
+      mat-flat-button
+      color="primary"
+      [disabled]="form.invalid"
+      (click)="createPost()"
+    >
+      投稿する
+    </button>
+    <button mat-stroked-button color="primary" matDialogClose>
+      キャンセル
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/create-my-menu/post-dialog/post-dialog.component.scss
+++ b/src/app/create-my-menu/post-dialog/post-dialog.component.scss
@@ -1,0 +1,156 @@
+.wrap {
+  text-align: center;
+}
+
+.title {
+  font-size: 20px;
+  margin: 0 0 16px;
+  font-weight: bold;
+  color: #8a4d41;
+}
+
+.form-field {
+  width: 100%;
+  margin: 0 0 8px;
+}
+
+.formArray {
+  display: flex;
+  flex-flow: column;
+  margin: 0 0 40px;
+}
+
+.dayOfWeek-title {
+  display: inline-block;
+  margin: 0 auto -12px;
+  padding: 0 8px;
+  font-weight: bold;
+  font-size: 18px;
+  color: #8a4d41;
+  background-color: #fff;
+  z-index: 1;
+}
+
+.radio-group {
+  margin: 0 0 24px;
+  border: 1px solid rgba(black, 0.14);
+  border-radius: 5px;
+  padding: 16px 8px 16px;
+  &:nth-last-child(1) {
+    margin: 0;
+  }
+  &__button {
+    margin-right: 16px;
+    &:nth-last-child(1) {
+      margin: 0;
+    }
+  }
+}
+
+.post {
+  background-color: #43a047;
+  border-radius: 4px;
+  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14),
+    0 1px 3px 0 rgba(0, 0, 0, 0.12);
+  position: relative;
+  // width: 80%;
+  margin: 0 auto 16px;
+  &__title {
+    font-size: 16px;
+    color: #fff;
+    font-weight: bold;
+    margin: 0;
+    padding: 16px;
+    letter-spacing: 2px;
+  }
+  &__foods-content {
+    padding-bottom: 80%;
+    position: relative;
+    overflow: hidden;
+  }
+  &__foods {
+    padding: 8px;
+    background-color: #f0eddd;
+    border-radius: 4px;
+    position: absolute;
+    box-shadow: 0 0 1px 1px rgba(black, 0.14);
+    &:nth-child(1) {
+      width: 50%;
+      top: -5%;
+      left: -2%;
+      transform: rotate(10deg);
+      z-index: 1;
+    }
+    &:nth-child(2) {
+      width: 55%;
+      top: -10%;
+      right: -2%;
+      transform: rotate(-8deg);
+    }
+    &:nth-child(3) {
+      width: 60%;
+      top: 33%;
+      left: -2%;
+      transform: rotate(6deg);
+    }
+    &:nth-child(4) {
+      width: 70%;
+      top: 25%;
+      right: -2%;
+      transform: rotate(-5deg);
+    }
+    &:nth-child(5) {
+      width: 60%;
+      top: 66%;
+      left: -3%;
+      transform: rotate(3deg);
+    }
+    &:nth-child(6) {
+      width: 50%;
+      top: 50%;
+      right: 0;
+      transform: rotate(4deg);
+    }
+    &:nth-child(7) {
+      width: 60%;
+      top: 75%;
+      right: -3%;
+      transform: rotate(-7deg);
+    }
+  }
+  &__food-images {
+    background-size: cover;
+    background-position: center;
+    padding-bottom: 56.25%;
+    border-radius: 4px;
+  }
+  &__user-content {
+    display: flex;
+    padding: 16px;
+  }
+  &__user-avater {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    margin: auto 8px auto 0;
+  }
+  &__user-content-right {
+    width: 240px;
+    text-align: left;
+    border-radius: 4px;
+  }
+  &__user-name {
+    color: #fff;
+    font-size: 14px;
+    font-weight: bold;
+    margin: 0 0 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  &__date {
+    color: #fff;
+    font-size: 13px;
+    margin: 0;
+  }
+}

--- a/src/app/create-my-menu/post-dialog/post-dialog.component.spec.ts
+++ b/src/app/create-my-menu/post-dialog/post-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PostDialogComponent } from './post-dialog.component';
+
+describe('PostDialogComponent', () => {
+  let component: PostDialogComponent;
+  let fixture: ComponentFixture<PostDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [PostDialogComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PostDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/create-my-menu/post-dialog/post-dialog.component.ts
+++ b/src/app/create-my-menu/post-dialog/post-dialog.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-post-dialog',
+  templateUrl: './post-dialog.component.html',
+  styleUrls: ['./post-dialog.component.scss'],
+})
+export class PostDialogComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/create-my-menu/post-dialog/post-dialog.component.ts
+++ b/src/app/create-my-menu/post-dialog/post-dialog.component.ts
@@ -1,4 +1,20 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+  FormArray,
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  Validators,
+} from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { DayMenuWithFood, MyMenu } from '@interfaces/my-menu';
+import { User } from '@interfaces/user';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MyMenuService } from 'src/app/services/my-menu.service';
+import { PostService } from 'src/app/services/post.service';
+import { UserService } from 'src/app/services/user.service';
 
 @Component({
   selector: 'app-post-dialog',
@@ -6,7 +22,111 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./post-dialog.component.scss'],
 })
 export class PostDialogComponent implements OnInit {
-  constructor() {}
+  form: FormGroup = this.fb.group({
+    title: ['', [Validators.required, Validators.maxLength(25)]],
+    dayOfWeeks: this.fb.array([]),
+  });
+  postData$: Observable<{
+    title: string;
+    thumbnailURLs: string[];
+  }> = this.form.valueChanges.pipe(
+    map((postData: { title: string; dayOfWeeks: string[] }) => {
+      const thumbnailURLs: string[] = postData.dayOfWeeks.map(
+        (dayOfWeek: string, index: number) => {
+          switch (dayOfWeek) {
+            case 'breakfast':
+              return this.data.weekMenu[index].breakfast.image;
+            case 'lunch':
+              return this.data.weekMenu[index].lunch.image;
+            case 'dinner':
+              return this.data.weekMenu[index].dinner.image;
+          }
+        }
+      );
+      return {
+        title: postData.title,
+        thumbnailURLs,
+      };
+    })
+  );
+  user$: Observable<User> = this.userService.getUserbyId(this.data.userId);
+  today: Date = new Date();
 
-  ngOnInit(): void {}
+  get titleControl(): FormControl {
+    return this.form.get('title') as FormControl;
+  }
+
+  get dayOfWeeksFormArray(): FormArray {
+    return this.form.get('dayOfWeeks') as FormArray;
+  }
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public data: {
+      weekMenu: DayMenuWithFood[];
+      myMenu: MyMenu;
+      userId: string;
+    },
+    private fb: FormBuilder,
+    private postService: PostService,
+    private snackBar: MatSnackBar,
+    private myMenuService: MyMenuService,
+    private userService: UserService,
+    private dialogRef: MatDialogRef<PostDialogComponent>
+  ) {}
+
+  ngOnInit(): void {
+    this.setFormArrayControls();
+    this.setDayOfWeeksFormArrayValue();
+  }
+
+  private setFormArrayControls(): void {
+    new Array(7).fill(null).forEach(() => {
+      this.dayOfWeeksFormArray.push(
+        this.fb.control([
+          '',
+          [Validators.required, Validators.pattern(/breakfast|lunch|dinner/)],
+        ])
+      );
+    });
+  }
+
+  private setDayOfWeeksFormArrayValue(): void {
+    const initialValue: string[] = new Array(7).fill('lunch');
+    this.dayOfWeeksFormArray.setValue(initialValue);
+  }
+
+  createPost(): void {
+    const formData: { title: string; dayOfWeeks: string[] } = this.form.value;
+    const thumbnailURLs: string[] = formData.dayOfWeeks.map(
+      (dayOfWeek: string, index: number) => {
+        switch (dayOfWeek) {
+          case 'breakfast':
+            return this.data.weekMenu[index].breakfast.image;
+          case 'lunch':
+            return this.data.weekMenu[index].lunch.image;
+          case 'dinner':
+            return this.data.weekMenu[index].dinner.image;
+        }
+      }
+    );
+    this.postService
+      .createPost({
+        day: this.data.myMenu.day,
+        creatorId: this.data.userId,
+        myMenuId: this.data.myMenu.myMenuId,
+        title: formData.title,
+        thumbnailURLs,
+      })
+      .then(() => {
+        this.snackBar.open('投稿に成功しました！', null);
+        this.dialogRef.close();
+        if (!this.data.myMenu.isPosted) {
+          this.myMenuService.changeMyMenuIsPosted(
+            this.data.myMenu.myMenuId,
+            true
+          );
+        }
+      });
+  }
 }

--- a/src/app/my-page/my-page/my-page.component.html
+++ b/src/app/my-page/my-page/my-page.component.html
@@ -59,16 +59,16 @@
                     *ngFor="let number of [1, 2]"
                   />
                   <p class="post__title">
-                    好物盛り合わせメニュー
+                    {{ post.title }}
                   </p>
                   <div class="post__foods-content">
-                    <ng-container *ngFor="let dayMenu of post.days">
+                    <ng-container
+                      *ngFor="let thumbnailURL of post.thumbnailURLs"
+                    >
                       <div class="post__foods">
                         <div
                           class="post__food-images"
-                          [style.background-image]="
-                            'url(' + dayMenu.lunch.image + ')'
-                          "
+                          [style.background-image]="'url(' + thumbnailURL + ')'"
                         ></div>
                       </div>
                     </ng-container>

--- a/src/app/post/post-detail/post-detail.component.html
+++ b/src/app/post/post-detail/post-detail.component.html
@@ -20,7 +20,7 @@
         <div class="week-grid">
           <div *ngFor="let menu of post.days; let i = index">
             <img
-              src="/assets/images/day-of-week{{ i }}.png"
+              src="/assets/images/titles/day-of-week-title{{ i }}.png"
               alt="{{ menu.dayOfWeek }}曜日のタイトル"
               class="day-of-week"
             />

--- a/src/app/post/post-detail/post-detail.component.html
+++ b/src/app/post/post-detail/post-detail.component.html
@@ -8,7 +8,7 @@
         class="wood-pins"
       />
       <h1 class="post-title">
-        <span class="post-title__text">好物盛り合わせメニュー</span>
+        <span class="post-title__text">{{ post.title }}</span>
       </h1>
       <div class="content">
         <img

--- a/src/app/post/post/post.component.html
+++ b/src/app/post/post/post.component.html
@@ -23,16 +23,14 @@
                 *ngFor="let number of [1, 2]"
               />
               <p class="post__title">
-                好物盛り合わせメニュー
+                {{ post.title }}
               </p>
               <div class="post__foods-content">
-                <ng-container *ngFor="let dayMenu of post.days">
+                <ng-container *ngFor="let thumbnailURL of post.thumbnailURLs">
                   <div class="post__foods">
                     <div
                       class="post__food-images"
-                      [style.background-image]="
-                        'url(' + dayMenu.lunch.image + ')'
-                      "
+                      [style.background-image]="'url(' + thumbnailURL + ')'"
                     ></div>
                   </div>
                 </ng-container>

--- a/src/app/services/post.service.ts
+++ b/src/app/services/post.service.ts
@@ -71,6 +71,8 @@ export class PostService {
           creatorId: post.creatorId,
           postId: post.postId,
           createdAt: post.createdAt,
+          title: post.title,
+          thumbnailURLs: post.thumbnailURLs,
         };
       })
     );

--- a/src/app/setting/account/account.component.html
+++ b/src/app/setting/account/account.component.html
@@ -64,6 +64,7 @@
     <p class="content-section__title">ユーザー名編集</p>
     <mat-form-field
       appearance="fill"
+      hintLabel="入力文字数"
       [hideRequiredMarker]="true"
       class="name-form"
     >
@@ -75,7 +76,9 @@
         placeholder="{{ user.name }}"
         [formControl]="nameForm"
         required
+        #input
       />
+      <mat-hint align="end">{{ input.value?.length || 0 }}/25</mat-hint>
       <mat-error *ngIf="nameForm.hasError('required')">必須入力です</mat-error>
       <mat-error *ngIf="nameForm.hasError('maxlength')"
         >最大文字数は25文字です</mat-error

--- a/src/app/user/user/user.component.html
+++ b/src/app/user/user/user.component.html
@@ -21,16 +21,14 @@
                 *ngFor="let number of [1, 2]"
               />
               <p class="post__title">
-                好物盛り合わせメニュー
+                {{ post.title }}
               </p>
               <div class="post__foods-content">
-                <ng-container *ngFor="let dayMenu of post.days">
+                <ng-container *ngFor="let thumbnailURL of post.thumbnailURLs">
                   <div class="post__foods">
                     <div
                       class="post__food-images"
-                      [style.background-image]="
-                        'url(' + dayMenu.lunch.image + ')'
-                      "
+                      [style.background-image]="'url(' + thumbnailURL + ')'"
                     ></div>
                   </div>
                 </ng-container>


### PR DESCRIPTION
fix #47 
以下のように実装しました。
ご確認のほどお願いします。
## 作業内容
- My献立投稿ダイアログ追加
- Post Interfaceにタイトルとサムネイル画像情報追加
- My献立投稿作成機能実装
- 各投稿確認ページに動的なタイトルとサムネイル画像の表示実装

![2a03b9a17da75aa6a086ddb7372d7b14](https://user-images.githubusercontent.com/63761544/98888002-5a37aa00-24da-11eb-99a4-3dff95ad6a65.gif)

